### PR TITLE
2511078; Soft dependency on entity modified

### DIFF
--- a/dfp.admin.inc
+++ b/dfp.admin.inc
@@ -122,6 +122,7 @@ function dfp_admin_settings($form, $form_state) {
   $form['global_tag_settings']['dfp_token_cache_enabled'] = array(
     '#type' => 'checkbox',
     '#title' => t("Enable DFP Token cache"),
+    '#disabled' => !module_exists('entity_modified'),
     '#default_value' => variable_get("dfp_token_cache_enabled", TRUE),
     '#description' => t('DFP custom cache for token replacements. Requires Entity Modified module.'),
   );
@@ -137,7 +138,6 @@ function dfp_admin_settings($form, $form_state) {
       ),
     ),
   );
-
 
   // Global display options.
   $form['global_display_options'] = array(
@@ -245,20 +245,19 @@ function dfp_admin_settings($form, $form_state) {
 /**
  * Submit handler for the global DFP settings form.
  */
-function dfp_admin_form_validate($element, &$form_state)
-{
+function dfp_admin_form_validate($element, &$form_state) {
   $settings = $element['global_tag_settings'];
   if (!empty($settings['dfp_click_url']['#value']) && $settings['dfp_async_rendering']['#value'] == 1) {
     form_error($settings['dfp_click_url'], t('Setting a click URL does not work with async rendering.'));
   }
 
   // Only allow DFP token cache if Entity modified is enabled.
-  if (($settings['dfp_token_cache_enabled']['#value']) == TRUE) {
-    if (!function_exists('entity_modified_last')) {
-      form_error($settings['dfp_token_cache_enabled'],
-        t('DFP token cache requires Entity Modified module.')
-      );
-    }
+  if ($settings['dfp_token_cache_enabled']['#value'] == TRUE &&
+    !function_exists('entity_modified_last')
+  ) {
+    form_error($settings['dfp_token_cache_enabled'],
+      t('DFP token cache requires Entity Modified module.')
+    );
   }
 }
 

--- a/dfp.admin.inc
+++ b/dfp.admin.inc
@@ -119,11 +119,23 @@ function dfp_admin_settings($form, $form_state) {
       ),
     ),
   );
+  $form['global_tag_settings']['dfp_token_cache_enabled'] = array(
+    '#type' => 'checkbox',
+    '#title' => t("Enable DFP Token cache"),
+    '#default_value' => variable_get("dfp_token_cache_enabled", TRUE),
+    '#description' => t('DFP custom cache for token replacements. Requires Entity Modified module.'),
+  );
   $form['global_tag_settings']['dfp_token_cache_lifetime'] = array(
     '#type' => 'textfield',
     '#title' => t("Token cache lifetime"),
+    '#size' => 6,
     '#default_value' => variable_get("dfp_token_cache_lifetime", 0),
     '#description' => t('The time, in seconds, that the DFP token cache will be valid for. The token cache will always be cleared at the next system cron run after this time period, or when this form is saved.'),
+    '#states' => array(
+      'visible' => array(
+        'input[name="dfp_token_cache_enabled"]' => array('checked' => TRUE),
+      ),
+    ),
   );
 
 
@@ -169,7 +181,6 @@ function dfp_admin_settings($form, $form_state) {
     '#default_value' => variable_get('dfp_set_centering', 0),
     '#description' => t('Enables/disables centering of ads. This mode must be set before the service is enabled. Centering is disabled by default. In legacy gpt_mobile.js, centering is enabled by default.'),
   );
-
 
   // Global targeting options.
   $form['targeting_settings'] = array(
@@ -239,6 +250,15 @@ function dfp_admin_form_validate($element, &$form_state)
   $settings = $element['global_tag_settings'];
   if (!empty($settings['dfp_click_url']['#value']) && $settings['dfp_async_rendering']['#value'] == 1) {
     form_error($settings['dfp_click_url'], t('Setting a click URL does not work with async rendering.'));
+  }
+
+  // Only allow DFP token cache if Entity modified is enabled.
+  if (($settings['dfp_token_cache_enabled']['#value']) == TRUE) {
+    if (!function_exists('entity_modified_last')) {
+      form_error($settings['dfp_token_cache_enabled'],
+        t('DFP token cache requires Entity Modified module.')
+      );
+    }
   }
 }
 

--- a/dfp.info
+++ b/dfp.info
@@ -13,7 +13,6 @@ configure = admin/structure/dfp_ads/settings
 dependencies[] = system
 dependencies[] = ctools
 dependencies[] = taxonomy
-dependencies[] = entity_modified
 
 files[] = plugins/export_ui/dfp_tag_ui.class.inc
 files[] = plugins/export_ui/dfp_ctools_export_ui.inc

--- a/dfp.install
+++ b/dfp.install
@@ -156,6 +156,8 @@ function dfp_install() {
 function dfp_uninstall() {
   // Delete variables.
   variable_del('dfp_set_centering');
+  variable_del('dfp_token_cache_enabled');
+  variable_del('dfp_token_cache_lifetime');
 }
 
 /**

--- a/dfp.install
+++ b/dfp.install
@@ -93,6 +93,27 @@ function dfp_schema() {
 }
 
 /**
+ * Implements hook_requirements().
+ */
+function dfp_requirements($phase) {
+  $requirements = array();
+  if ($phase == 'runtime') {
+    if (variable_get('dfp_token_cache_enabled', 0)) {
+      if (!function_exists('entity_modified_last')) {
+        $requirements['dfp_token_cache'] = array(
+          'title' => t('DFP dependency'),
+          'value' => t('DFP token cache requires Entity Modified module.'),
+          'description' => t('Please install <a href="@module">Entity Modified</a> module or disable the option.', array('@module' => 'https://www.drupal.org/project/entity_modified')),
+          'severity' => REQUIREMENT_ERROR,
+        );
+      }
+    }
+  }
+
+  return $requirements;
+}
+
+/**
  * Implements hook_install().
  */
 function dfp_install() {

--- a/dfp.module
+++ b/dfp.module
@@ -862,8 +862,6 @@ function _dfp_prepare_adunit($tag) {
  * @see token_replace()
  */
 function dfp_token_replace($text, $tag = NULL, array $options = array()) {
-  $processed_strings =& drupal_static(__FUNCTION__, NULL);
-
   // Short-circuit the degenerate case, just like token_replace() does.
   $text_tokens = token_scan($text);
   if (empty($text_tokens)) {
@@ -874,6 +872,30 @@ function dfp_token_replace($text, $tag = NULL, array $options = array()) {
   // @todo This doesn't vary, so we could probably refactor it to be cached,
   // too.
   $data = _dfp_prepare_tokens($tag);
+
+  // Tokens cache.
+  $dfp_token_cache_enabled = variable_get('dfp_token_cache_enabled', TRUE);
+  if ($dfp_token_cache_enabled && function_exists('entity_modified_last')) {
+    $replacement = _dfp_token_replace_cache($text, $data, $options);
+  }
+  else {
+    $replacement = token_replace($text, $data, $options);
+  }
+
+  return $replacement;
+}
+
+/**
+ * Helper to store and retrieve tokens from cache.
+ *
+ * @param       $text
+ * @param null  $tag
+ * @param array $options
+ *
+ * @return mixed
+ */
+function _dfp_token_replace_cache($text, $data, array $options = array()) {
+  $processed_strings =& drupal_static(__FUNCTION__, NULL);
 
   // Determine the cache key for this text string. That way we can cache
   // reliably.

--- a/tests/dfp.test
+++ b/tests/dfp.test
@@ -11,7 +11,7 @@ class dfpBaseTest extends DrupalWebTestCase {
    */
   function setUp() {
     // Enable a couple modules.
-    parent::setUp('ctools', 'dfp', 'taxonomy');
+    parent::setUp('ctools', 'dfp', 'taxonomy', 'entity_modified');
     menu_rebuild();
 
     // Create an admin user with all the permissions needed to run tests.


### PR DESCRIPTION
- Made DFP token cache optional, since not everyone needs it. Added new option in the admin UI
- Only show the cache lifetime input when token cache is ticked
- Added a validation to prevent enabling the cache while Entity modified is not enabled (I am checking if the function exists, rather then module exists, just in case they change the API for any reason)
- Removed dependency on Entity Modified and turned into a soft dependency.
- Added a hook_requirement to show the relevant message.
- And lastly, moved the caching logic into a helper function _dfp_token_replace_cache()

ps: do not merge this PR